### PR TITLE
fix(common): change dir before pulling latest from git

### DIFF
--- a/common/download_coreboot.sh
+++ b/common/download_coreboot.sh
@@ -36,6 +36,7 @@ function gitUpdate() {
 ##
 ################################################################################
 function checkoutTag() {
+  cd "$DOCKER_COREBOOT_DIR" || exit
   git checkout tags/"$COREBOOT_TAG" || exit
   git submodule update --recursive --remote
 }
@@ -47,8 +48,14 @@ function checkoutTag() {
 ##
 ################################################################################
 function checkoutCommit() {
-#edge should checkout master
+  cd "$DOCKER_COREBOOT_DIR" || exit
+  # bleeding-edge should checkout master
   git checkout "$COREBOOT_COMMIT" || exit
+
+  if  [ "$COREBOOT_COMMIT" == "master"  ]; then
+    git pull --all
+  fi
+
   git submodule update --recursive --remote
 }
 ################################################################################


### PR DESCRIPTION
I found a bug in the git checkout functions.  In both `checkoutCommit` and `checkoutTag` the scope of current directory not preserved from the previous function and reverting back to default.  These functions were fetching the latest code from the skulls repo instead of coreboot repo.