### PR TITLE
x230: skip ram voltage check

### DIFF
--- a/x230/README.md
+++ b/x230/README.md
@@ -33,9 +33,8 @@ branch is _not_ meant to be stable. Use it for testing only.
 ## First-time installation
 #### before you begin
 Before starting, run Linux on your X230, install `dmidecode` and run
-`sudo ./x230_before_first_install.sh`. It simply prints system information and helps
-you find out your RAM voltage. Make sure you have RAM that uses
-[1,5V, not 1,35V](https://www.coreboot.org/Intel_Native_Raminit#Sandybridge.2FIvybridge).
+`sudo ./x230_before_first_install.sh`. It simply prints system information and
+helps you to be up to date.
 Also make sure you have the latest skulls-x230 package release by running `./upgrade.sh`.
 
 #### original BIOS update / EC firmware (optional)

--- a/x230/x230_before_first_install.sh
+++ b/x230/x230_before_first_install.sh
@@ -66,17 +66,3 @@ elif [ "${bios_minor}" -ge "60" ] ; then
 else
 	echo -e "The installed original BIOS is very old. ${RED}please upgrade${NC} before installing coreboot."
 fi
-
-echo "Please search for your SODIMM RAM and verify that it uses 1,5 Volts (not 1,35V):"
-dmidecode -t memory | grep Part | grep -v "Not Specified" | sort -u | cut -d':' -f2 | sed 's/ //'
-RAM_SPEC=$(dmidecode -t memory | grep Part | grep -v "Not Specified" | sort -u | cut -d':' -f2 | sed 's/ //')
-
-read -r -p "Open a browser and search for it? [y/N] " response
-case "$response" in
-	[yY][eE][sS]|[yY])
-		xdg-open "https://duckduckgo.com/?q=${RAM_SPEC}!"
-		;;
-	*)
-		exit 0
-	;;
-esac


### PR DESCRIPTION
This simplifies setup by remove the unneeded RAM voltage checking.

According to the spec, DDR3L RAM has to work using 1.5V, see
https://en.wikipedia.org/wiki/DDR3_SDRAM#DDR3L_and_DDR3U_extensions.
Coreboot simply doesn't always implement changing voltage, which
can never prevent RAM from working though.

Closes #38