### PR TITLE
x230: external_install_bottom: fix automatic detection of chip

### DIFF
--- a/x230/external_install_bottom.sh
+++ b/x230/external_install_bottom.sh
@@ -153,14 +153,20 @@ if [ ! "$have_chipname" -gt 0 ] ; then
 
 	CHIPNAME=""
 	chip_found=0
-	CHIPNAME=$(cat "${TEMP_DIR}"/chips | grep Found | grep "MX25L6406E/MX25L6408E" | grep -oP '"\K[^"\047]+(?=["\047])' || true)
-	if [ ! -z "${CHIPNAME}" ] ; then
-		chip_found=1
+	if [ ! "$chip_found" -gt 0 ] ; then
+		CHIPNAME=$(cat "${TEMP_DIR}"/chips | grep Found | grep "MX25L6406E/MX25L6408E" | grep -oP '"\K[^"\047]+(?=["\047])' || true)
+		if [ ! -z "${CHIPNAME}" ] ; then
+			chip_found=1
+		fi
 	fi
-	CHIPNAME=$(cat "${TEMP_DIR}"/chips | grep Found | grep "EN25QH64" | grep -o '".*"' || true)
-	if [ ! -z "${CHIPNAME}" ] ; then
-		chip_found=1
+
+	if [ ! "$chip_found" -gt 0 ] ; then
+		CHIPNAME=$(cat "${TEMP_DIR}"/chips | grep Found | grep "EN25QH64" | grep -o '".*"' || true)
+		if [ ! -z "${CHIPNAME}" ] ; then
+			chip_found=1
+		fi
 	fi
+
 	if [ ! "$chip_found" -gt 0 ] ; then
 		echo "chip not detected."
 		flashrom -p ${programmer} || true


### PR DESCRIPTION
in fact, detecting MX25L6406E/MX25L6408E has not worked. only EN25QH64
was detected because the former got overwritten. fix the logic and
detect either one.

Fixes #52