### PR TITLE
x230: increase rpi's spispeed

### DIFF
--- a/x230/external_install_bottom.sh
+++ b/x230/external_install_bottom.sh
@@ -115,7 +115,7 @@ if [ ! "$have_flasher" -gt 0 ] ; then
 fi
 
 if [ ! "${rpi_frequency}" -gt 0 ] ; then
-	rpi_frequency=128
+	rpi_frequency=512
 fi
 
 programmer=""

--- a/x230/external_install_top.sh
+++ b/x230/external_install_top.sh
@@ -132,7 +132,7 @@ if [ ! "$have_flasher" -gt 0 ] ; then
 fi
 
 if [ ! "${rpi_frequency}" -gt 0 ] ; then
-	rpi_frequency=128
+	rpi_frequency=512
 fi
 
 programmer=""


### PR DESCRIPTION
While I think I have initially used 128 from some libreboot docs and never
had problems with it, I don't really see anybody use less than 512 right
now.

That said, I love how there's youtube tutials complaining about that, like https://www.youtube.com/watch?v=9sSbFufySJk so maybe we should keep the slow speed :)