### PR TITLE
x230: remove checking for the very latest Lenovo BIOS

### DIFF
--- a/x230/README.md
+++ b/x230/README.md
@@ -69,20 +69,9 @@ In case you're not running the latest BIOS version, either
 By default, only original Lenovo batteries are allowed.
 Thanks to [this](http://zmatt.net/unlocking-my-lenovo-laptop-part-3/)
 [project](https://github.com/eigenmatt/mec-tools) we can use Lenovo's bootable
-upgrade image, change it and create a bootable _USB_ image, with an EC update
-that allows us to use any 3rd party aftermarket battery:
-
-
-		sudo apt-get install build-essential git mtools libssl-dev
-		git clone https://github.com/hamishcoleman/thinkpad-ec && cd thinkpad-ec
-		make patch_disable_keyboard clean
-		make patch_enable_battery clean
-		make patched.x230.img
-
-
-That's it. You can create a bootable USB stick: `sudo dd if=patched.x230.img of=/dev/sdx`
-and boot from it. Alternatively, burn `patched.x230.iso` to a CD. And make sure
-you have "legacy" boot set, not "UEFI" boot.
+upgrade image, change it and create a bootable _USB_ image (even with EC updates
+that allows to use 3rd party aftermarket batteries). For this, follow instructions
+at [github.com/hamishcoleman/thinkpad-ec](https://github.com/hamishcoleman/thinkpad-ec).
 
 #### preparation: required hardware
 * An 8 Pin SOIC Clip, for example from

--- a/x230/x230_before_first_install.sh
+++ b/x230/x230_before_first_install.sh
@@ -57,12 +57,9 @@ BIOS_VERSION=$(dmidecode -s bios-version | grep -o '[1-2].[0-7][0-9]')
 bios_major=$(echo "$BIOS_VERSION" | cut -d. -f1)
 bios_minor=$(echo "$BIOS_VERSION" | cut -d. -f2)
 
-if [ "${bios_minor}" -eq "74" ] ; then
-	echo -e "${GREEN}latest BIOS version${NC} installed. Nothing to do."
-elif [ "${bios_minor}" -ge "60" ] ; then
+if [ "${bios_minor}" -ge "60" ] ; then
 	echo "installed BIOS version is ${bios_major}.${bios_minor}."
-	echo "That's not the latest version, but the EC version is."
-	echo "You may upgrade before installing coreboot if you want."
 else
-	echo -e "The installed original BIOS is very old. ${RED}please upgrade${NC} before installing coreboot."
+	echo -e "The installed original BIOS is very old and doesn't include the latest Embedded Controller Firmware."
+	echo -e "${RED}Please upgrade${NC} before installing coreboot."
 fi


### PR DESCRIPTION
This makes things easier to maintain and simply causes less confusion
for users. We only want the lastest EC firmware.

see #77 