### PR TITLE
Include Wiring Photo Link in x230/README.md

### DIFF
--- a/x230/README.md
+++ b/x230/README.md
@@ -1,4 +1,4 @@
-# Skulls - [Thinkpad X230](https://pcsupport.lenovo.com/en/products/laptops-and-netbooks/thinkpad-x-series-laptops/thinkpad-x230) and X230T
+up to date: Frequently a new image with the latest versions of all components# Skulls - [Thinkpad X230](https://pcsupport.lenovo.com/en/products/laptops-and-netbooks/thinkpad-x-series-laptops/thinkpad-x230) and X230T
 
 ![seabios_bootmenu](front.jpg)
 
@@ -151,6 +151,8 @@ or ethernet to `sudo apt-get install flashrom`
 
 Now copy the Skulls release tarball over to the Rasperry Pi and
 [continue](#unpack-the-skulls-release-archive) on the Pi.
+
+**Note**: For beginner users please reference [this photo](https://coinsh.red/u/vgdhgdsavd.png).
 
 #### Hardware Example: CH341A based
 The CH341A from [Winchiphead](http://www.wch.cn/), a USB interface chip,


### PR DESCRIPTION
**Basic Description**: Include Wiring Photo Link in README.md
In particular, this link:

**Why?**: It appears that the current x230 README does not have any guide for wiring the clip and the RPI. My PR just adds a tiny URL for people like myself who could not find instructions on wiring.

___________________________________________