### PR TITLE
Update README.md (new EC Firmware 1.15 and its problems have to be meantioned)

### DIFF
--- a/x230/README.md
+++ b/x230/README.md
@@ -64,8 +64,9 @@ supported anymore, once you're running coreboot (You'd have to manually
 flash back your backup images first, see later chapters).
 
 This updates the BIOS _and_ Embedded Controller (EC) firmware. The EC
-is not updated anymore, when running coreboot. The latest EC version is 1.15
-which is included with the latest official BIOS release 2.77 from 04 Oct 2019.
+is not updated anymore, when running coreboot. Since official BIOS release 2.77 and
+its EC version 1.15 Lenovo includes a digital signature check, which prevents
+further firmware patching.
 
 
 You have 2 options:

--- a/x230/README.md
+++ b/x230/README.md
@@ -64,13 +64,15 @@ supported anymore, once you're running coreboot (You'd have to manually
 flash back your backup images first, see later chapters).
 
 This updates the BIOS _and_ Embedded Controller (EC) firmware. The EC
-is not updated anymore, when running coreboot. The latest EC version is 1.14
-and that's unlikely to change.
+is not updated anymore, when running coreboot. The latest EC version is 1.15
+which is included with the latest official BIOS release 2.77 from 04 Oct 2019.
+
 
 You have 2 options:
 
 * use [the latest original CD](https://pcsupport.lenovo.com/us/en/products/laptops-and-netbooks/thinkpad-x-series-laptops/thinkpad-x230/downloads/ds029187) and burn it, or
 * use the same, only with a patched EC firmware that allows using any aftermarket-battery:
+(this is only possible up to EC Firmware 1.14)
 By default, only original Lenovo batteries are allowed.
 Thanks to [this](http://zmatt.net/unlocking-my-lenovo-laptop-part-3/)
 [project](https://github.com/eigenmatt/mec-tools) we can use Lenovo's bootable


### PR DESCRIPTION
The description was just wrong, since there is a new EC firmware version on Lenovo website. And it also has the drawback of not being compatible with the X220 keyboard mod.
This is also described on https://github.com/hamishcoleman/thinkpad-ec