### PR TITLE
modify scripts to fallback to traditional commands if no systemd

### DIFF
--- a/util/functions.sh
+++ b/util/functions.sh
@@ -57,3 +57,11 @@ warn_not_root() {
 		echo -e "${YELLOW}WARNING:${NC} This should not be executed as root!"
 	fi
 }
+
+poweroff() {
+    if command -v systemctl 2>/dev/null; then
+        systemctl poweroff
+    else
+        shutdown -P now
+    fi
+}

--- a/x230/x230_heads.sh
+++ b/x230/x230_heads.sh
@@ -155,8 +155,8 @@ rm -rf ${OUTPUT_PATH}
 while true; do
 	read -r -p "Power off now? (please do!) Y/n: " yn
 	case $yn in
-		[Yy]* ) systemctl poweroff ;;
+		[Yy]* ) poweroff ;;
 		[Nn]* ) exit;;
-		* ) systemctl poweroff ;;
+		* ) poweroff ;;
 	esac
 done

--- a/x230/x230_skulls.sh
+++ b/x230/x230_skulls.sh
@@ -217,8 +217,8 @@ rm -rf ${OUTPUT_PATH}
 while true; do
 	read -r -p "Power off now? (please do!) Y/n: " yn
 	case $yn in
-		[Yy]* ) systemctl poweroff ;;
+		[Yy]* ) poweroff ;;
 		[Nn]* ) exit;;
-		* ) systemctl poweroff ;;
+		* ) poweroff ;;
 	esac
 done


### PR DESCRIPTION
for portability, fall back to traditional UNIX commands for poweroff when `systemctl` is not found