### PR TITLE
Add OSBoot's table for 'Test Clip pinout for SO8/SOIC8/SOIC-8 flash chip'

### DIFF
--- a/x230/README.md
+++ b/x230/README.md
@@ -154,7 +154,6 @@ or ethernet to `sudo apt-get install flashrom`
 | 7 | *not used* | *not used* |
 | 8 | 3.3V |  |
 
-Table from OSBoot's wiki: https://osboot.org/docs/install/rpi_setup.html
 
 Connect corresponding RPI Pins, according to the images above.
 


### PR DESCRIPTION
OS Boot has a really easy and simple documentation of setting up flashing via the Raspberry Pi, this PR hopes to apply some of these here. 
________________________________

Source: https://osboot.org/docs/install/rpi_setup.html
- https://notabug.org/osboot/osbwww/raw/master/www/docs/install/rpi_setup.md

