### PR TITLE
fixed typo

### DIFF
--- a/t430/README.md
+++ b/t430/README.md
@@ -217,7 +217,7 @@ for more details.
 
 ### replace the splashscreen image
 In order to create your own splashscreen image, before building,
-overwrite the `splashscreen.jpg` with your own JPEG, using
+overwrite the `bootsplash.jpg` with your own JPEG, using
 * "Progressive" turned off, and
 * "4:2:0 (chroma quartered)" Subsampling
 

--- a/t440p/README.md
+++ b/t440p/README.md
@@ -214,7 +214,7 @@ for more details.
 
 ### replace the splashscreen image
 In order to create your own splashscreen image, before building,
-overwrite the `splashscreen.jpg` with your own JPEG, using
+overwrite the `bootsplash.jpg` with your own JPEG, using
 * "Progressive" turned off, and
 * "4:2:0 (chroma quartered)" Subsampling
 

--- a/t530/README.md
+++ b/t530/README.md
@@ -217,7 +217,7 @@ for more details.
 
 ### replace the splashscreen image
 In order to create your own splashscreen image, before building,
-overwrite the `splashscreen.jpg` with your own JPEG, using
+overwrite the `bootsplash.jpg` with your own JPEG, using
 * "Progressive" turned off, and
 * "4:2:0 (chroma quartered)" Subsampling
 

--- a/x230/README.md
+++ b/x230/README.md
@@ -275,7 +275,7 @@ for more details.
 
 ### replace the splashscreen image
 In order to create your own splashscreen image, before building,
-overwrite the `splashscreen.jpg` with your own JPEG, using
+overwrite the `bootsplash.jpg` with your own JPEG, using
 * "Progressive" turned off, and
 * "4:2:0 (chroma quartered)" Subsampling
 

--- a/x230t/README.md
+++ b/x230t/README.md
@@ -272,7 +272,7 @@ for more details.
 
 ### replace the splashscreen image
 In order to create your own splashscreen image, before building,
-overwrite the `splashscreen.jpg` with your own JPEG, using
+overwrite the `bootsplash.jpg` with your own JPEG, using
 * "Progressive" turned off, and
 * "4:2:0 (chroma quartered)" Subsampling
 


### PR DESCRIPTION
there is no file named `splashscreen.jpg`, `bootsplash.jpg` is the file that should be overwritten