### PR TITLE
Use env to find bash and python

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Tom Hiller <thrilleratplay@gmail.com>
 set -e

--- a/common/config_and_make.sh
+++ b/common/config_and_make.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Tom Hiller <thrilleratplay@gmail.com>
 

--- a/common/download_coreboot.sh
+++ b/common/download_coreboot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Tom Hiller <thrilleratplay@gmail.com>
 

--- a/common/variables.sh
+++ b/common/variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Tom Hiller <thrilleratplay@gmail.com>
 

--- a/external_install_bottom.sh
+++ b/external_install_bottom.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Martin Kepplinger <martink@posteo.de>
 RED='\033[0;31m'

--- a/external_install_top.sh
+++ b/external_install_top.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Martin Kepplinger <martink@posteo.de>
 RED='\033[0;31m'

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Martin Kepplinger <martink@posteo.de>
 #

--- a/skulls.sh
+++ b/skulls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2019, Martin Kepplinger <martink@posteo.de>
 

--- a/t430/build.sh
+++ b/t430/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "util/functions.sh"
 
 warn_not_root

--- a/t430/compile.sh
+++ b/t430/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Tom Hiller <thrilleratplay@gmail.com>
 

--- a/t440p/build.sh
+++ b/t440p/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "util/functions.sh"
 
 warn_not_root

--- a/t440p/compile.sh
+++ b/t440p/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Tom Hiller <thrilleratplay@gmail.com>
 

--- a/t530/build.sh
+++ b/t530/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "util/functions.sh"
 
 warn_not_root

--- a/t530/compile.sh
+++ b/t530/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Tom Hiller <thrilleratplay@gmail.com>
 

--- a/util/functions.sh
+++ b/util/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Martin Kepplinger <martink@posteo.de>
 RED='\033[0;31m'

--- a/util/me_cleaner/me_cleaner.py
+++ b/util/me_cleaner/me_cleaner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # me_cleaner - Tool for partial deblobbing of Intel ME/TXE firmware images
 # Copyright (C) 2016-2018 Nicola Corna <nicola@corna.info>

--- a/util/me_cleaner/setup.py
+++ b/util/me_cleaner/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from setuptools import setup
 

--- a/x230/build.sh
+++ b/x230/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "util/functions.sh"
 
 warn_not_root

--- a/x230/compile.sh
+++ b/x230/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Tom Hiller <thrilleratplay@gmail.com>
 

--- a/x230/x230_heads.sh
+++ b/x230/x230_heads.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Martin Kepplinger <martink@posteo.de>
 

--- a/x230/x230_heads_extract_blobs.sh
+++ b/x230/x230_heads_extract_blobs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2019, Martin Kepplinger <martink@posteo.de>
 

--- a/x230t/build.sh
+++ b/x230t/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "util/functions.sh"
 
 warn_not_root

--- a/x230t/compile.sh
+++ b/x230t/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Tom Hiller <thrilleratplay@gmail.com>
 

--- a/x230t/x230t_heads.sh
+++ b/x230t/x230t_heads.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0+
 # Copyright (C) 2018, Martin Kepplinger <martink@posteo.de>
 


### PR DESCRIPTION
This allows using skulls on NixOs and others unix system that do not `bash` and `python` on `/bin` or `/usr/bin`.