### PR TITLE
common: do not track submodule branches on update

### DIFF
--- a/common/download_coreboot.sh
+++ b/common/download_coreboot.sh
@@ -38,7 +38,7 @@ function gitUpdate() {
 function checkoutTag() {
   cd "$DOCKER_COREBOOT_DIR" || exit
   git checkout tags/"$COREBOOT_TAG" || exit
-  git submodule update --checkout --recursive
+  git submodule update --init --checkout --recursive
 }
 ################################################################################
 
@@ -56,7 +56,7 @@ function checkoutCommit() {
     git pull --all
   fi
 
-  git submodule update --checkout --recursive
+  git submodule update --init --checkout --recursive
 }
 ################################################################################
 

--- a/common/download_coreboot.sh
+++ b/common/download_coreboot.sh
@@ -16,7 +16,7 @@ function gitUpdate() {
     # Clone Coreboot and fetch submodules
     git clone https://github.com/coreboot/coreboot.git "$DOCKER_COREBOOT_DIR"
     cd "$DOCKER_COREBOOT_DIR" || exit
-    git submodule update --init --recursive --remote
+    git submodule update --init --checkout --recursive
 
     # blobs are ignored from updates.  Manually clone to prevent compile errors later from non empty directory cloning
     # git clone https://github.com/coreboot/blobs.git 3rdparty/blobs/
@@ -38,7 +38,7 @@ function gitUpdate() {
 function checkoutTag() {
   cd "$DOCKER_COREBOOT_DIR" || exit
   git checkout tags/"$COREBOOT_TAG" || exit
-  git submodule update --recursive --remote
+  git submodule update --checkout --recursive
 }
 ################################################################################
 
@@ -56,7 +56,7 @@ function checkoutCommit() {
     git pull --all
   fi
 
-  git submodule update --recursive --remote
+  git submodule update --checkout --recursive
 }
 ################################################################################
 


### PR DESCRIPTION
The "--remote" on "git submodule update" will track the submodule branches and check out commits not actually recorded in the superproject.
Makefile.mk from coreboot will actually fall back to the recorded commits anyways. But having checked out additional commits during "git describe" will make our build appear "dirty", because "git describe" is called before the submodules are updated once more.

Closes: #254