### PR TITLE
move build.sh to common directory

### DIFF
--- a/common/build.sh
+++ b/common/build.sh
@@ -11,7 +11,7 @@ set -e
 ################################################################################
 
 ## Parse avialble models from directory names
-AVAILABLE_MODELS=$(find ./ -maxdepth 1 -mindepth 1 -type d | sed  's/\.\///g' | grep -Ev "common|git")
+AVAILABLE_MODELS=$(find ./ -maxdepth 1 -mindepth 1 -type d | sed  's/\.\///g' | grep -Ev "common|git|util")
 
 ## Help menu
 usage()

--- a/t430/build.sh
+++ b/t430/build.sh
@@ -77,5 +77,5 @@ CONFIGFILE_READY=$(echo $CONFIGFILE | cut -d'-' -f2-)
 cp $CONFIGFILE $CONFIGFILE_READY
 
 cd ..
-./build.sh --clean-slate --commit $(ls -1 t430/defconfig-* |  cut -d'-' -f2-) t430
+./common/build.sh --clean-slate --commit $(ls -1 t430/defconfig-* |  cut -d'-' -f2-) t430
 rm -f t430/defconfig-*

--- a/t440p/build.sh
+++ b/t440p/build.sh
@@ -77,5 +77,5 @@ CONFIGFILE_READY=$(echo $CONFIGFILE | cut -d'-' -f2-)
 cp $CONFIGFILE $CONFIGFILE_READY
 
 cd ..
-./build.sh --clean-slate --commit $(ls -1 t440p/defconfig-* |  cut -d'-' -f2-) t440p
+./common/build.sh --clean-slate --commit $(ls -1 t440p/defconfig-* |  cut -d'-' -f2-) t440p
 rm -f t440p/defconfig-*

--- a/t530/build.sh
+++ b/t530/build.sh
@@ -77,5 +77,5 @@ CONFIGFILE_READY=$(echo $CONFIGFILE | cut -d'-' -f2-)
 cp $CONFIGFILE $CONFIGFILE_READY
 
 cd ..
-./build.sh --clean-slate --commit $(ls -1 t530/defconfig-* |  cut -d'-' -f2-) t530
+./common/build.sh --clean-slate --commit $(ls -1 t530/defconfig-* |  cut -d'-' -f2-) t530
 rm -f t530/defconfig-*

--- a/w530/build.sh
+++ b/w530/build.sh
@@ -77,5 +77,5 @@ CONFIGFILE_READY=$(echo $CONFIGFILE | cut -d'-' -f2-)
 cp $CONFIGFILE $CONFIGFILE_READY
 
 cd ..
-./build.sh --clean-slate --commit $(ls -1 w530/defconfig-* |  cut -d'-' -f2-) w530
+./common/build.sh --clean-slate --commit $(ls -1 w530/defconfig-* |  cut -d'-' -f2-) w530
 rm -f w530/defconfig-*

--- a/x230/build.sh
+++ b/x230/build.sh
@@ -77,5 +77,5 @@ CONFIGFILE_READY=$(echo $CONFIGFILE | cut -d'-' -f2-)
 cp $CONFIGFILE $CONFIGFILE_READY
 
 cd ..
-./build.sh --clean-slate --commit $(ls -1 x230/defconfig-* |  cut -d'-' -f2-) x230
+./common/build.sh --clean-slate --commit $(ls -1 x230/defconfig-* |  cut -d'-' -f2-) x230
 rm -f x230/defconfig-*

--- a/x230t/build.sh
+++ b/x230t/build.sh
@@ -77,5 +77,5 @@ CONFIGFILE_READY=$(echo $CONFIGFILE | cut -d'-' -f2-)
 cp $CONFIGFILE $CONFIGFILE_READY
 
 cd ..
-./build.sh --clean-slate --commit $(ls -1 x230t/defconfig-* |  cut -d'-' -f2-) x230t
+./common/build.sh --clean-slate --commit $(ls -1 x230t/defconfig-* |  cut -d'-' -f2-) x230t
 rm -f x230t/defconfig-*


### PR DESCRIPTION
in order to avoid confusion: only <model>/build.sh is to be used by users.

Closes: https://github.com/merge/skulls/issues/309